### PR TITLE
feat: add --tags option to print test tag counts table

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Demo test names 💻
         run: npm run demo-names
 
+      - name: Demo test names and tags 💻
+        run: npm run demo-tags
+
       - name: Unit tests 🧪
         run: npm test
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ found 2 specs (4 tests, 1 pending)
 
 Where the tags are listed inside `[ ... ]` (see [cypress-grep](https://github.com/cypress-io/cypress-grep)) and the [pending tests](https://glebbahmutov.com/blog/cypress-test-statuses/) are marked with `⊙` character.
 
+## Test tags
+
+You can count tags attached to the individual tests using `--names --tags` arguments
+
+```
+$ npx find-cypress-specs --names --tags
+# prints the specs and tests and at the end prints the tags table
+
+Tag    Test count
+-----  ----------
+@user  2
+@sign  1
+```
+
 ## Details
 
 Cypress uses the resolved [configuration values](https://on.cypress.io/configuration) to find the spec files to run. It searches the `integrationFolder` for all patterns listed in `testFiles` and removes any files matching the `ignoreTestFiles` patterns.

--- a/bin/find.js
+++ b/bin/find.js
@@ -4,13 +4,18 @@ const arg = require('arg')
 const { getSpecs } = require('../src')
 const fs = require('fs')
 const pluralize = require('pluralize')
-const { getTestNames, formatTestList } = require('find-test-names')
+const { getTestNames, formatTestList, countTags } = require('find-test-names')
+const consoleTable = require('console.table')
 
 const args = arg({
   '--names': Boolean,
+  '--tags': Boolean,
 
   // aliases
   '-n': '--names',
+  '--name': '--names',
+  '-t': '--tags',
+  '--tag': '--tags',
 })
 
 const specs = getSpecs()
@@ -21,6 +26,10 @@ if (args['--names']) {
     console.log('')
     let testsN = 0
     let pendingTestsN = 0
+
+    // counts the number of tests for each tag across all specs
+    const tagTestCounts = {}
+
     specs.forEach((filename) => {
       const source = fs.readFileSync(filename, 'utf8')
       const result = getTestNames(source, true)
@@ -43,6 +52,17 @@ if (args['--names']) {
       }
       console.log(formatTestList(result.structure))
       console.log('')
+
+      if (args['--tags']) {
+        const specTagCounts = countTags(result.structure)
+        Object.keys(specTagCounts).forEach((tag) => {
+          if (!(tag in tagTestCounts)) {
+            tagTestCounts[tag] = specTagCounts[tag]
+          } else {
+            tagTestCounts[tag] += specTagCounts[tag]
+          }
+        })
+      }
     })
 
     if (pendingTestsN) {
@@ -60,6 +80,15 @@ if (args['--names']) {
       )
     }
     console.log('')
+
+    if (args['--tags']) {
+      const table = consoleTable.getTable(
+        ['Tag', 'Test count'],
+        Object.entries(tagTestCounts),
+      )
+      console.log(table)
+      console.log('')
+    }
   }
 } else {
   console.log(specs.join(','))

--- a/cypress/e2e/featureA/user.js
+++ b/cypress/e2e/featureA/user.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-it('works', () => {})
+it('works', { tags: '@user' }, () => {})
 
 // pending test
 it('needs to be written')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1235,6 +1235,12 @@
         }
       }
     },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "optional": true
+    },
     "code-excerpt": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-3.0.0.tgz",
@@ -1379,6 +1385,14 @@
             "signal-exit": "^3.0.2"
           }
         }
+      }
+    },
+    "console.table": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/console.table/-/console.table-0.10.0.tgz",
+      "integrity": "sha1-CRcCVYiHW+/XDPLv9L7yxuLXXQQ=",
+      "requires": {
+        "easy-table": "1.1.0"
       }
     },
     "conventional-changelog-angular": {
@@ -1669,6 +1683,15 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "optional": true,
+      "requires": {
+        "clone": "^1.0.2"
+      }
+    },
     "del": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
@@ -1784,6 +1807,14 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+    },
+    "easy-table": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.1.0.tgz",
+      "integrity": "sha1-hvmrTBAvA3G3KXuSplHVgkvIy3M=",
+      "requires": {
+        "wcwidth": ">=1.0.1"
+      }
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -2010,9 +2041,9 @@
       }
     },
     "find-test-names": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/find-test-names/-/find-test-names-1.12.1.tgz",
-      "integrity": "sha512-Fmz3ASexV2z1O5DqypmQX8Ey+w2icNVq+VkAllWULj96P9vXhm4yvi+IE20bfgKePufCoWRU4LPWQ3jqxbWcTg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/find-test-names/-/find-test-names-1.13.0.tgz",
+      "integrity": "sha512-sWc2JomDXOiZaIvoEwp4Ya4w0s4cwZH6adgedObwgg0o9TbsIRYlzEC6BHR+P/F4Tkj5dn86EMHMhUl7dqBosw==",
       "requires": {
         "@babel/parser": "^7.16.5",
         "acorn-walk": "^8.2.0",
@@ -7318,6 +7349,15 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "optional": true,
+      "requires": {
+        "defaults": "^1.0.3"
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "cy:run": "DEBUG=cypress:cli,cypress:server:specs cypress run",
     "demo": "DEBUG=find-cypress-specs node ./bin/find",
     "demo-names": "node ./bin/find --names",
+    "demo-tags": "node ./bin/find --names --tags",
     "semantic-release": "semantic-release"
   },
   "repository": {
@@ -38,8 +39,9 @@
   },
   "dependencies": {
     "arg": "^5.0.1",
+    "console.table": "^0.10.0",
     "debug": "^4.3.3",
-    "find-test-names": "^1.12.1",
+    "find-test-names": "^1.13.0",
     "globby": "^11.0.4",
     "minimatch": "^3.0.4",
     "pluralize": "^8.0.0"


### PR DESCRIPTION
for #6 

```
$ npx find-cypress-specs --names --tags
# prints the specs and tests and at the end prints the tags table

Tag    Test count
-----  ----------
@user  2
@sign  1
```