### PR TITLE
feat: add --parent parameter to find changed specs in the current branch

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout 🛎
+        # https://github.com/actions/checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Install dependencies 📦
         # https://github.com/cypress-io/github-action

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,20 @@
+name: pr
+on: pull_request
+jobs:
+  changed-files:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout 🛎
+        uses: actions/checkout@v3
+
+      - name: Install dependencies 📦
+        # https://github.com/cypress-io/github-action
+        uses: cypress-io/github-action@v3
+        with:
+          runTests: false
+
+      - name: Print files changed against the parent of this branch 🌳
+        run: git diff --name-only --diff-filter=AMR HEAD^!
+
+      - name: Print specs changed against the parent of this branch 🌳
+        run: node ./bin/find --parent

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,9 @@ jobs:
       - name: Checkout 🛎
         # https://github.com/actions/checkout
         uses: actions/checkout@v3
+        # check out all the commits in the repo
+        # to make sure we detect the changed files in this branch
+        # against its parent commit
         with:
           fetch-depth: 0
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,29 @@ $ npx find-cypress-specs --branch main
 # prints only some specs, the ones that have changed against the "origin/main"
 ```
 
+## against the parent commit
+
+When dealing with a long-term branch, you do not want to see the changed files in the main branch. Instead, you want to only consider the specs changed in the _current_ branch all the way to its parent commit. You can pass the flag `--parent` to only pick the modified and added specs.
+
+```bash
+$ npx find-cypress-specs --parent
+# same as
+# git diff --name-only --diff-filter=AMR HEAD^!
+```
+
+Note: in order to trace the commits back to the parent commit of the branch, fetch the entire repo or enough commits to have this information when checking out the repo. For example, in [pr.yml](./.github/workflows/pr.yml) we fetch the entire history
+
+```yml
+- name: Checkout 🛎
+  # https://github.com/actions/checkout
+  uses: actions/checkout@v3
+  # check out all the commits in the repo
+  # to make sure we detect the changed files in this branch
+  # against its parent commit
+  with:
+    fetch-depth: 0
+```
+
 ### number of changed files
 
 You can print just the number of changed specs

--- a/bin/find.js
+++ b/bin/find.js
@@ -1,7 +1,12 @@
 #!/usr/bin/env node
 
 const arg = require('arg')
-const { getSpecs, collectResults, findChangedFiles } = require('../src')
+const {
+  getSpecs,
+  collectResults,
+  findChangedFiles,
+  findChangedFilesAgainstParent,
+} = require('../src')
 const { pickTaggedTestsFrom } = require('../src/tagged')
 const { addCounts } = require('../src/count')
 const { stringAllInfo } = require('../src/print')
@@ -18,6 +23,8 @@ const args = arg({
   '--json': Boolean,
   // find the specs that have changed against this Git branch
   '--branch': String,
+  // find the specs that have changed against the parent of this branch
+  '--parent': Boolean,
   '--count': Boolean,
   // filter all tests to those that have the given tag
   '--tagged': String,
@@ -112,6 +119,16 @@ if (args['--names'] || args['--tags']) {
 } else if (args['--branch']) {
   debug('determining specs changed against branch %s', args['--branch'])
   const changedFiles = findChangedFiles(args['--branch'])
+  debug('changed files %o', changedFiles)
+  const changedSpecs = specs.filter((file) => changedFiles.includes(file))
+  if (args['--count']) {
+    console.log(changedSpecs.length)
+  } else {
+    console.log(changedSpecs.join(','))
+  }
+} else if (args['--parent']) {
+  debug('determining specs changed against the parent of this branch')
+  const changedFiles = findChangedFilesAgainstParent()
   debug('changed files %o', changedFiles)
   const changedSpecs = specs.filter((file) => changedFiles.includes(file))
   if (args['--count']) {

--- a/src/index.js
+++ b/src/index.js
@@ -116,10 +116,33 @@ function findChangedFiles(branch) {
   }
 
   // can we find updated and added files?
-  const result = shell.exec(
-    `git diff --name-only --diff-filter=AMR origin/${branch}`,
-    { silent: true },
-  )
+  debug('finding changed files against %s', branch)
+  const command = `git diff --name-only --diff-filter=AMR origin/${branch}`
+  debug('command: %s', command)
+
+  const result = shell.exec(command, { silent: true })
+  if (result.code !== 0) {
+    debug('git diff failed with code %d', result.code)
+    return []
+  }
+
+  const filenames = result.stdout.split('\n').filter(Boolean)
+  return filenames
+}
+
+/**
+ * Finds files modified or added against the parent commit of the current branch.
+ * Returns a list of filenames. If there are no files, returns an empty list.
+ */
+function findChangedFilesAgainstParent() {
+  if (!shell.which('git')) {
+    shell.echo('Sorry, this script requires git')
+    return []
+  }
+
+  const result = shell.exec(`git diff --name-only --diff-filter=AMR HEAD^!`, {
+    silent: true,
+  })
   if (result.code !== 0) {
     debug('git diff failed with code %d', result.code)
     return []
@@ -136,4 +159,5 @@ module.exports = {
   findCypressSpecs,
   collectResults,
   findChangedFiles,
+  findChangedFilesAgainstParent,
 }

--- a/src/index.js
+++ b/src/index.js
@@ -115,6 +115,7 @@ function findChangedFiles(branch) {
     return []
   }
 
+  // can we find updated and added files?
   const result = shell.exec(
     `git diff --name-only --diff-filter=AMR origin/${branch}`,
     { silent: true },


### PR DESCRIPTION
Without considering the files changed in the main branch. Will be very helpful for long-term pull requests