### PR TITLE
feat: support custom cypress config file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Demo tags in json output 💻
         run: npm run demo-tags-json
 
+      - name: Demo with custom cypress config 💻
+        run: npm run demo-custom-cypress-config
+
       - name: Print specs changed against the main branch 🌳
         run: npm run print-changed-specs
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "demo-names": "DEBUG=find-cypress-specs node ./bin/find --names",
     "demo-skipped-tests": "DEBUG=find-cypress-specs node ./bin/find --names --skipped",
     "demo-count-skipped-tests": "DEBUG=find-cypress-specs node ./bin/find --names --skipped --count",
+    "demo-custom-cypress-config": "DEBUG=find-cypress-specs CYPRESS_CONFIG_FILE=test-ts/cypress.config.custom.ts node ./bin/find",
     "demo-tags": "node ./bin/find --tags",
     "demo-tags-json": "node ./bin/find --tags --json",
     "demo-names-and-tags": "node ./bin/find --names --tags",

--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,21 @@ function getConfigTs(filename) {
 }
 
 function getConfig() {
+  if (typeof process.env.CYPRESS_CONFIG_FILE !== 'undefined') {
+    const configFile = process.env.CYPRESS_CONFIG_FILE
+    if (configFile.endsWith('.js')) {
+      debug(`found file ${configFile}`);
+      return getConfigJs(`./${configFile}`)
+    } else if (configFile.endsWith('.ts')) {
+      debug(`found file ${configFile}`);
+      return getConfigTs(`./${configFile}`)
+    } else if (configFile.endsWith('.json')) {
+      debug(`found file ${configFile}`);
+      return getConfigJson(`./${configFile}`)
+    } 
+    throw new Error('Config file should be .ts, .js or .json file even when using CYPRESS_CONFIG_FILE env var')
+  }
+
   if (fs.existsSync('./cypress.config.js')) {
     debug('found file cypress.config.js')
     return getConfigJs('./cypress.config.js')
@@ -66,7 +81,7 @@ function getConfig() {
     return getConfigJson('./cypress.json')
   }
 
-  throw new Error('Do not know how to find and load Cypress config file')
+  throw new Error('Config file should be .ts, .js or .json file')
 }
 
 function findCypressSpecsV9(opts = {}) {

--- a/test-ts/cypress.config.custom.ts
+++ b/test-ts/cypress.config.custom.ts
@@ -1,0 +1,10 @@
+const { defineConfig } = require('cypress')
+
+module.exports = defineConfig({
+  e2e: {
+    supportFile: false,
+    fixturesFolder: false,
+    setupNodeEvents(on, config) {
+    },
+  },
+})


### PR DESCRIPTION
Would like to add support for custom named cypress config files.

Proposal:

- Custom cypress config file can be passed via CYPRESS_CONFIG_FILE env var

Testing:
- Tried to add the corresponding ava test, but based on my experience it is difficult to test env variables with ava
- Added demo task to the CI file

Todo:
- Upon green light for the feature, I will extend add to the documentation