### PR TITLE
Fix usage of fast-glob API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -149,7 +149,9 @@ function findCypressSpecsV10(opts = {}, type = 'e2e') {
   /** @type string[] */
   const files = globby.sync(options.specPattern, {
     sort: true,
-    ignore: options.excludeSpecPattern,
+    ignore: Array.isArray(options.excludeSpecPattern)
+      ? options.excludeSpecPattern
+      : [options.excludeSpecPattern],
   })
   debug('found %d file(s) %o', files.length, files)
 


### PR DESCRIPTION
globby depends on fast-glob which introduced a breaking change in 3.3.0. Their API has been expecting an string[] for `ignore` option for awhile but in the latest version it causes a TypeError. Make sure the `ignore` option is passed an array.

Fixes issues for: https://github.com/bahmutov/cypress-split/issues/78#issuecomment-1630108191